### PR TITLE
Took out comment on html question component

### DIFF
--- a/Calm/src/app/questions/questions.component.html
+++ b/Calm/src/app/questions/questions.component.html
@@ -13,7 +13,7 @@
             a lot of different things,
              for a period of 6 months or more?</label><br>
              </div>   </div>
-            // html form containing user questions relating to anxiety
+            
              <div class="row">
                 <div class="col-1">
         <input type="checkbox" id="2" name="2" value=" -Social Anxiety- ">


### PR DESCRIPTION
There was an html comment that was made on the question component which I took out because it was displaying on the main page as seen after the recent deployment. This pull request should take care of that. 